### PR TITLE
Fix conanfile generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 /.coverage
 /docs/_build/
 /dist/
+build/

--- a/autorecipes/cmake.py
+++ b/autorecipes/cmake.py
@@ -17,17 +17,26 @@ from autorecipes.descriptors import (
 from autorecipes.stdlib import Object, named, zero_or_more
 
 
+def prepare_requires(requires):
+    result = ""
+    for line in requires:
+        if isinstance(line, tuple):
+            result += "{}\n".format(line[0])
+        else:
+            result += "{}\n".format(line)
+    return result
+
 def generate_conanfile_txt(requires, build_requires, generators) -> str:
     """Generate contents of a ``conanfile.txt``."""
     text = ''
     if requires:
         text += '[requires]\n'
-        text += ''.join(f'{line}\n' for line in requires)
+        text += prepare_requires(requires)
     if build_requires:
         text += '[build_requires]\n'
-        text += ''.join(f'{line}\n' for line in build_requires)
+        text += prepare_requires(build_requires)
     if text and generators:
-        text += '[generators]'
+        text += '[generators]\n'
         text += ''.join(f'{line}\n' for line in generators)
     return text
 

--- a/autorecipes/cmake.py
+++ b/autorecipes/cmake.py
@@ -86,9 +86,12 @@ class CMakeListsTxtAttributes:
                 sp.run(
                     [
                         'cmake',
+                        '-DCONAN_EXPORTED=YES',
                         *toolchain_args,
                         str(source_dir),
                     ],
+                    stdout=sp.DEVNULL,
+                    stderr=sp.DEVNULL,
                     cwd=step1_dir,
                 )
 
@@ -100,9 +103,12 @@ class CMakeListsTxtAttributes:
                     sp.run(
                         [
                             'cmake',
+                            '-DCONAN_EXPORTED=YES',
                             f'-DSTEP1_DIR={step1_dir}',
                             str(data_dir / 'configure'),
                         ],
+                        stdout=sp.DEVNULL,
+                        stderr=sp.DEVNULL,
                         cwd=step2_dir,
                     )
 


### PR DESCRIPTION
Here are some fixes for CMake invocation, for projects which are using [Conan CMake](https://github.com/conan-io/cmake-conan) script.
Fix for `conanfile.txt` generator provides correct requirements parsing for [tuple format](https://docs.conan.io/en/latest/reference/conanfile/attributes.html#requires)